### PR TITLE
fix:修改接口optimize接口支持的文件类型

### DIFF
--- a/harmony/photo_manipulator/src/main/ets/OptimizeUtils.ts
+++ b/harmony/photo_manipulator/src/main/ets/OptimizeUtils.ts
@@ -46,7 +46,7 @@ export async function setOptimize(backgroundPixelMap: image.PixelMap, filename, 
 
 function generateCacheFilePath(saveFormat: string | null): string {
   const cacheDir = globalThis.context.cacheDir;
-  let ext = ".jpg";
+  let ext = "jpg";
   if (saveFormat) {
     ext = getFileExtension(saveFormat);
   }

--- a/harmony/photo_manipulator/src/main/ets/OverlayUtil.ts
+++ b/harmony/photo_manipulator/src/main/ets/OverlayUtil.ts
@@ -87,7 +87,7 @@ export async function saveImage(backgroundPixelMap: image.PixelMap, format: stri
 
 function generateCacheFilePath(saveFormat: string | null): string {
   const cacheDir = globalThis.context.cacheDir;
-  let ext = ".jpg";
+  let ext = "jpg";
   if (saveFormat) {
     ext = getFileExtension(saveFormat);
   }

--- a/harmony/photo_manipulator/src/main/ets/PhotoManipulatorTurboModule.ts
+++ b/harmony/photo_manipulator/src/main/ets/PhotoManipulatorTurboModule.ts
@@ -117,7 +117,7 @@ export class PhotoManipulatorTurboModule extends AnyThreadTurboModule{
   }
 
   async optimize(imageUrl: string, quality: number): Promise<string> {
-    if (imageUrl.endsWith(".jpg") || imageUrl.endsWith(".jpeg")) {
+    if (imageUrl.endsWith(".jpg") || imageUrl.endsWith(".jpeg") || imageUrl.endsWith(".webp") || imageUrl.endsWith(".png")) {
       const fileName: string = imageUrl.substring(imageUrl.lastIndexOf('/') + 1);
       const imageSRC: RNImageSRC = await obtainImageInfoFromPath(this.resourceManager, imageUrl);
       const decodingOptions: image.DecodingOptions = {

--- a/harmony/photo_manipulator/src/main/ets/PrintTextUtils.ts
+++ b/harmony/photo_manipulator/src/main/ets/PrintTextUtils.ts
@@ -137,7 +137,7 @@ async function saveImage(backgroundPixelMap: image.PixelMap, format: string, qua
 
 function generateCacheFilePath(saveFormat: string | null): string {
   const cacheDir = globalThis.context.cacheDir;
-  let ext = ".jpg";
+  let ext = "jpg";
   if (saveFormat) {
     ext = getFileExtension(saveFormat);
   }

--- a/harmony/photo_manipulator/src/main/ets/RegionItem.ts
+++ b/harmony/photo_manipulator/src/main/ets/RegionItem.ts
@@ -69,6 +69,7 @@ export class DefaultConstants {
 export enum SaveFormat {
   png = 'png',
   jpg = 'jpg',
+  jpeg = 'jpeg',
 }
 
 export class ImagePosition{

--- a/harmony/photo_manipulator/src/main/ets/Utils.ts
+++ b/harmony/photo_manipulator/src/main/ets/Utils.ts
@@ -59,7 +59,7 @@ export function getImageUri(url: string): string {
 export function getFileExtension(format: string): string {
   switch (format) {
     case "image/jpeg":
-      return SaveFormat.jpg;
+      return SaveFormat.jpeg;
     case "image/png":
       return SaveFormat.png;
     default:


### PR DESCRIPTION
# Summary
1:fix:修改接口optimize接口支持的文件类型

## Test Plan
![photo-manipulator](https://github.com/user-attachments/assets/92ce43e3-8b04-4202-987d-6976f37f451f)


## Checklist
- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)
